### PR TITLE
A new way to count the number of rows

### DIFF
--- a/Datatables/Datatable.php
+++ b/Datatables/Datatable.php
@@ -735,8 +735,8 @@ class Datatable
      */
     public function getCountAllResults()
     {
-        $qb = $this->repository->createQueryBuilder($this->tableName)
-            ->select('count(' . $this->tableName . '.' . $this->rootEntityIdentifier . ')');
+        $qb = clone $this->qb;
+        $qb->select('count(' . $this->tableName . '.' . $this->rootEntityIdentifier . ')');
 
         if (!empty($this->callbacks['WhereBuilder']) && $this->hideFilteredCount)  {
             foreach ($this->callbacks['WhereBuilder'] as $callback) {
@@ -752,7 +752,7 @@ class Datatable
      */
     public function getCountFilteredResults()
     {
-        $qb = $this->repository->createQueryBuilder($this->tableName);
+        $qb = clone $this->qb;
         $qb->select('count(distinct ' . $this->tableName . '.' . $this->rootEntityIdentifier . ')');
         $this->setAssociations($qb);
         $this->setWhere($qb);


### PR DESCRIPTION
Instead of to recreate a querybuilder for count the number of row, why not just clone the actual QueryBuilder?

In the case where we use this kind of code :

``` php
$datatable = $this->get('lankit_datatables')->getDatatable('WaldoMyBundle:Customer');

// Construction of DQL query
$datatable->makeSearch();

/* @var $queryBuilder \Doctrine\ORM\QueryBuilder */
$qb = $datatable->getQueryBuilder(); // we retrieve the QueryBuilder

// Here we add what we want in the query
// But I don't know why, it doesn't work really good if I use $qb->addSelect
$qb->select("Organisme.id, Organisme.sigle, Organisme.libelle, COUNT(ShoppingCart.id) as nbShoppingCart");
$qb->leftJoin("Customer.shoppingCart", "ShoppingCart")
->where(/* Lot of realy hard stuf */);

// We execute the query
$dataTableResult = $datatable->executeSearch();

// Add generate the response !
return $dataTableResult->getSearchResultsResponse();
```

When count of row is done the WHERE part isn't include. So we don't have the real number of row.

But if we just clone the QueryBuilder, it 's work fine (In my case).
