### PR TITLE
passing a callback function to getSearchResults() to allow manipulation ...

### DIFF
--- a/Datatables/Datatable.php
+++ b/Datatables/Datatable.php
@@ -680,13 +680,14 @@ class Datatable
         return $this;
     }
 
-    /**
+  /**
      * Creates and executes the DataTables search, returns data in the requested format
      *
-     * @param string The result type to use, should be one of: RESULT_JSON, RESULT_ARRAY, RESULT_RESPONSE
+     * @param $resultType string The result type to use, should be one of: RESULT_JSON, RESULT_ARRAY, RESULT_RESPONSE
+     * @param $callback function A callback function to allow the client to manipulate the row data in php
      * @return mixed The DataTables data in the requested/default format
      */
-    public function getSearchResults($resultType = '')
+    public function getSearchResults($resultType = '', $callback=null)
     {
         if (empty($resultType) || !defined('self::RESULT_' . strtoupper($resultType))) {
             $resultType = $this->defaultResultType;
@@ -698,9 +699,15 @@ class Datatable
         $this->makeSearch();
         $this->executeSearch();
 
+
+
+        if (is_callable($callback)){
+            $this->datatable['aaData'] = $callback($this->datatable['aaData']);
+        }
+
         return call_user_func(array(
-            $this, 'getSearchResults' . $resultType
-        ));
+                                   $this, 'getSearchResults' . $resultType
+                              ));
     }
 
     /**


### PR DESCRIPTION
Hi there,

Thanks for creating this library. We found it very useful. However, one issue we had was that we wanted to be able to manipulate the data on a per column basis in php. Useful features for this could include doing things like returning correctly formed url links in columns and formatting dates etc.

We took a look at your code and changed it only very slightly. We added a callback function to getSearchResults().

Here is some sample client code, which in this case would format a DateTime object that comes back in a 'createdAt' field:

```
<?PHP 

$standardResult = $obj->getSearchResults(Datatable::RESULT_ARRAY, function($dataSet){

            foreach ($dataSet as $Outerkey => $row){

               foreach($row as $key=>$value){

                        switch ($key){
                            case 'createdAt':
                                $row[$key] = $value->format('Y-m-d');
                                break;
                            default:
                                break;
                        }

                $dataSet[$Outerkey] = $row;

               }
            }

            return $dataSet;
        });
?>
```

We have tested this using all methods (json and response), and it seems to work in all cases. We think this helps make your code more useful. Thanks!

Paul
